### PR TITLE
Adding custom timeout for TCP client

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,8 @@ Tag                         | Layout | yes      | Fluentd tag name              
 UseSsl                      | bool   | no       | Use SSL/TLS to connect to the fluentd node                   | false
 ValidateCertificate         | bool   | no       | Validate the certificate returned by the fluentd node        | true
 Enabled                     | Layout | no       | Enables or disables sending messages to fluentd              | true
-SendTimeout                 | Layout | yes      | amount of time it will wait for a send operation to complete | 3000
+AsyncConnection             | Layout | yes      | Setting to enable/disable the custom timeout                 | false
+AsyncConnectionTimeout      | Layout | yes      | Sets the custom timeout in case the target is not reachable  | false
 
 For fluentd use case I recommend using the Buffering Wrapper (or the Async one), along with a fallback option.
 
@@ -38,7 +39,8 @@ For fluentd use case I recommend using the Buffering Wrapper (or the Async one),
                 useSsl="true"
                 ValidateCertificate="false"
                 layout="${message}"
-                SendTimeout="3000"
+                AsyncConnection="false"
+                AsyncConnectionTimeout="5000"
                 />      
         <target xsi:type="File"
                 name="fluentd-file-fallback"

--- a/README.md
+++ b/README.md
@@ -14,16 +14,15 @@ Usage
 -----
 The `<target />` configuration section contains three required fields.
 
-Setting                     | Type   | Required | Description                                                  | Default       
---------------------------- |------- |--------- |------------------------------------------------------------- | --------------
-Host                        | Layout | yes      | Host name of the fluentd node                                | 127.0.0.1
-Port                        | Layout | yes      | Port number of the fluentd node                              | 24224
-Tag                         | Layout | yes      | Fluentd tag name                                             | nlog
-UseSsl                      | bool   | no       | Use SSL/TLS to connect to the fluentd node                   | false
-ValidateCertificate         | bool   | no       | Validate the certificate returned by the fluentd node        | true
-Enabled                     | Layout | no       | Enables or disables sending messages to fluentd              | true
-AsyncConnection             | Layout | yes      | Setting to enable/disable the custom timeout                 | false
-AsyncConnectionTimeout      | Layout | yes      | Sets the custom timeout in case the target is not reachable  | false
+Setting                     | Type   | Required | Description                                                                                   | Default       
+--------------------------- |------- |--------- |---------------------------------------------------------------------------------------------- | --------------
+Host                        | Layout | yes      | Host name of the fluentd node                                                                 | 127.0.0.1
+Port                        | Layout | yes      | Port number of the fluentd node                                                               | 24224
+Tag                         | Layout | yes      | Fluentd tag name                                                                              | nlog
+UseSsl                      | bool   | no       | Use SSL/TLS to connect to the fluentd node                                                    | false
+ValidateCertificate         | bool   | no       | Validate the certificate returned by the fluentd node                                         | true
+Enabled                     | Layout | no       | Enables or disables sending messages to fluentd                                               | true
+ConnectionTimeout           | Layout | yes      | Sets a custom timeout in case the target is not reachable. Set it to "0" for Default timeout  | 5000
 
 For fluentd use case I recommend using the Buffering Wrapper (or the Async one), along with a fallback option.
 
@@ -39,8 +38,7 @@ For fluentd use case I recommend using the Buffering Wrapper (or the Async one),
                 useSsl="true"
                 ValidateCertificate="false"
                 layout="${message}"
-                AsyncConnection="false"
-                AsyncConnectionTimeout="5000"
+                ConnectionTimeout="5000"
                 />      
         <target xsi:type="File"
                 name="fluentd-file-fallback"

--- a/src/Demo/Demo.csproj
+++ b/src/Demo/Demo.csproj
@@ -96,10 +96,6 @@
   <ItemGroup>
     <None Include="App.config" />
     <None Include="Demo_TemporaryKey.pfx" />
-    <None Include="NLog.config">
-      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
-      <SubType>Designer</SubType>
-    </None>
     <None Include="NLog.config.sample" />
     <None Include="packages.config" />
     <None Include="Properties\app.manifest" />

--- a/src/Demo/NLog.config.sample
+++ b/src/Demo/NLog.config.sample
@@ -24,8 +24,7 @@
               ValidateCertificate="false"
               layout="${message}"
               enabled="${mdlc:item=FluendEnabled}"
-              AsyncConnection="false"
-              AsyncConnectionTimeout="5000"
+              ConnectionTimeout="5000"
               />      
       <target xsi:type="File"
               name="fluentd-file-fallback"

--- a/src/Demo/NLog.config.sample
+++ b/src/Demo/NLog.config.sample
@@ -24,7 +24,8 @@
               ValidateCertificate="false"
               layout="${message}"
               enabled="${mdlc:item=FluendEnabled}"
-              SendTimeout="3000"
+              AsyncConnection="false"
+              AsyncConnectionTimeout="5000"
               />      
       <target xsi:type="File"
               name="fluentd-file-fallback"

--- a/src/NLog.Fluentd/FluentdTarget.cs
+++ b/src/NLog.Fluentd/FluentdTarget.cs
@@ -19,8 +19,7 @@ namespace NLog.Fluentd
         private string _fluentdHost;
         private string _tag;
         private int _fluentdPort;
-        private bool _asyncConnection;
-        private int _asyncConnTimeout;
+        private int _connTimeout;
         private TcpClient client;
         private Stream stream;
         private FluentdPacker packer;
@@ -69,32 +68,17 @@ namespace NLog.Fluentd
         }
 
         /// <summary>
-        /// Flag to identify if connection is Assynchronous
-        /// </summary>
-        [RequiredParameter]
-        [DefaultValue("False")]
-        public Layout AsyncConnection
-        {
-            get
-            { return _asyncConnection.ToString(); }
-            set
-            {
-                _asyncConnection = bool.Parse(value?.Render(LogEventInfo.CreateNullEvent()));
-            }
-        }
-
-        /// <summary>
         /// Sets the Timeout for Assynchronous connections
         /// </summary>
         [RequiredParameter]
         [DefaultValue("3000")]
-        public Layout AsyncConnectionTimeout
+        public Layout ConnectionTimeout
         {
             get
-            { return _asyncConnTimeout.ToString(); }
+            { return _connTimeout.ToString(); }
             set
             {
-                _asyncConnTimeout = int.Parse(value?.Render(LogEventInfo.CreateNullEvent()));
+                _connTimeout = int.Parse(value?.Render(LogEventInfo.CreateNullEvent()));
             }
         }
 
@@ -147,9 +131,9 @@ namespace NLog.Fluentd
 
             try
             {
-                if (this._asyncConnection.Equals(true))
+                if (this._connTimeout > 0)
                 {
-                    this.client.ConnectAsync(_fluentdHost, _fluentdPort).Wait(_asyncConnTimeout);
+                    this.client.ConnectAsync(_fluentdHost, _fluentdPort).Wait(_connTimeout);
                 }
                 else
                 {

--- a/src/NLog.Fluentd/IFluentdTarget.cs
+++ b/src/NLog.Fluentd/IFluentdTarget.cs
@@ -37,14 +37,8 @@ namespace NLog.Fluentd
         Layout Enabled { get; set; }
 
         /// <summary>
-        /// Used in conjunction with the connection timeout (setting below). If enabled, a custom timeout for the connection attempt can be set
-        /// </summary>
-        Layout AsyncConnection { get; set; }
-
-        /// <summary>
         /// How long (in miliseconds) the connection will wait before it timesout. 
-        /// Used in conjunction with the "AsyncConnection" setting above. This number is only considered if the above is enabled.
         /// </summary>
-        Layout AsyncConnectionTimeout { get; set; }
+        Layout ConnectionTimeout { get; set; }
     }
 }

--- a/src/NLog.Fluentd/IFluentdTarget.cs
+++ b/src/NLog.Fluentd/IFluentdTarget.cs
@@ -37,8 +37,14 @@ namespace NLog.Fluentd
         Layout Enabled { get; set; }
 
         /// <summary>
-        /// Sets the amount of time a TcpClient will wait for a send operation to complete successfully.
+        /// Used in conjunction with the connection timeout (setting below). If enabled, a custom timeout for the connection attempt can be set
         /// </summary>
-        Layout SendTimeout { get; set; }
+        Layout AsyncConnection { get; set; }
+
+        /// <summary>
+        /// How long (in miliseconds) the connection will wait before it timesout. 
+        /// Used in conjunction with the "AsyncConnection" setting above. This number is only considered if the above is enabled.
+        /// </summary>
+        Layout AsyncConnectionTimeout { get; set; }
     }
 }


### PR DESCRIPTION
Added two new settings for the NLog extension:

             AsyncConnection="true/false"
             AsyncConnectionTimeout="number in milliseconds"

They both in conjunction. The timeout will only be considered if the Async Connection setting is enabled.



